### PR TITLE
Run dry-run merge workflow on issue_comment too

### DIFF
--- a/.github/workflows/merge-dry-run.yml
+++ b/.github/workflows/merge-dry-run.yml
@@ -1,5 +1,5 @@
 name: "Perform dry-run merge"
-on: [pull_request]
+on: [pull_request, issue_comment]
 jobs:
   merge-dry-run:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What has been done
1. Added `merge-dry-run` workflow execution on `issue_comment` actions too to help with testing Action integration

### How to test
1. Make sure that the `merge-dry-run` workflow is executed when comment is posted in PR

Can be tested only after merge to `master` as per [docs](https://help.github.com/en/actions/reference/events-that-trigger-workflows)

![image](https://user-images.githubusercontent.com/3036347/82491292-21031c00-9aed-11ea-85e5-2f9e2aa58962.png)

