### PR TITLE
Reference PullRequest object properties from issue comment payload #29

### DIFF
--- a/src/github/pull-request.js
+++ b/src/github/pull-request.js
@@ -1,8 +1,8 @@
 class PullRequest {
-  constructor(payload) {
-    this.owner = payload.repository.owner.login;
-    this.number = payload.pull_request.number;
-    this.repo = payload.repository.name;
+  constructor(issueCommentPayload) {
+    this.owner = issueCommentPayload.repository.owner.login;
+    this.number = issueCommentPayload.issue.number;
+    this.repo = issueCommentPayload.repository.name;
   }
 }
 module.exports = PullRequest;


### PR DESCRIPTION

### What has been done
1. Referenced `PullRequest` object properties from issue comment payload
2. Added skip of the workflow in case action build wasn't triggered from PR comment

`comment` payload differs from `pull-request` payload so required fields are located in different child objects.
See `test/fixture/**.json` for various payload examples.

### How to test
1. Merge PR
2. Leave a comment on PR and check action build result
