### PR TITLE
Add future merge commands support

### DIFF
--- a/src/github/pull-request.js
+++ b/src/github/pull-request.js
@@ -5,4 +5,5 @@ class PullRequest {
     this.repo = issueCommentPayload.repository.name;
   }
 }
+
 module.exports = PullRequest;

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ const {context: githubContext} = github;
 
 const octokit = github.getOctokit(GITHUB_TOKEN);
 
-// on PR
+// ✓ on PR
 // on comment with command `/robin squash-merge` or `/robin rebase-merge`
 // check mergeability & return early otherwise
 // check all PR checks are passing & return early otherwise

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ const {context: githubContext} = github;
 const octokit = github.getOctokit(GITHUB_TOKEN);
 
 // ✓ on PR
-// on comment with command `/robin squash-merge` or `/robin rebase-merge`
+// on comment with command `/robin merge` | `/robin squash-merge` | `/robin rebase-merge`
 // check mergeability & return early otherwise
 // check all PR checks are passing & return early otherwise
 // get list of commits

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ const {context: githubContext} = github;
 const octokit = github.getOctokit(GITHUB_TOKEN);
 
 // ✓ on PR
-// on comment with command `/robin merge` | `/robin squash-merge` | `/robin rebase-merge`
+// ✓ on comment with command `/robin merge` | `/robin squash-merge` | `/robin rebase-merge`
 // check mergeability & return early otherwise
 // check all PR checks are passing & return early otherwise
 // get list of commits

--- a/src/robin/robin-command.js
+++ b/src/robin/robin-command.js
@@ -1,17 +1,24 @@
-const ROBIN_COMMAND = '/robin';
-const HAS_DRY_RUN_FLAG = '--dry-run';
-
 class RobinCommand {
   constructor(commentBody) {
     this.commentBody = commentBody;
   }
 
+  /**
+   * Performs case-insensitve search for robin command in commendy body
+   * /robin + <command> + <flags>
+   *
+   * @return {boolean} True when comment contains robin command, false - otherwise
+   */
   isRobinCommand() {
-    return this.commentBody.toLowerCase().includes(ROBIN_COMMAND.toLowerCase());
+    const robinCommands = `/robin`
+        .concat(` (merge|squash-merge|rebase-merge)`)
+        .concat(`( --dry-run)?`);
+    return new RegExp(robinCommands, 'i').test(this.commentBody);
   }
 
   isDryRunMode() {
-    return this.commentBody.includes(HAS_DRY_RUN_FLAG);
+    return new RegExp('--dry-run', 'i').test(this.commentBody);
   }
 }
+
 module.exports = RobinCommand;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,3 +1,0 @@
-test('true is true', () => {
-  expect(true).toBe(true);
-});

--- a/test/robin/robin-command.test.js
+++ b/test/robin/robin-command.test.js
@@ -1,0 +1,49 @@
+const RobinCommand = require('../../src/robin/robin-command');
+
+test('identifies merge command', () => {
+  expect(new RobinCommand('/robin merge').isRobinCommand()).toBe(true);
+});
+
+test('identifies squash-merge command', () => {
+  expect(new RobinCommand('/robin squash-merge').isRobinCommand()).toBe(true);
+});
+
+test('identifies rebase-merge command', () => {
+  expect(new RobinCommand('/robin rebase-merge').isRobinCommand()).toBe(true);
+});
+
+test('identifies merge command ingoring the case', () => {
+  expect(new RobinCommand('/Robin merGE').isRobinCommand()).toBe(true);
+});
+
+test('identifies merge command with --dry-run flag', () => {
+  expect(new RobinCommand('/robin merge --dry-run').isRobinCommand()).toBe(true);
+});
+
+test('doesn\'t identify merge command without leading slash (\/)', () => {
+  expect(new RobinCommand('robin merge').isRobinCommand()).toBe(false);
+});
+
+test('doesn\'t identify unknown command', () => {
+  expect(new RobinCommand('/robin no-such-command').isRobinCommand()).toBe(false);
+});
+
+test('doesn\'t identify correct command at wrong position', () => {
+  expect(new RobinCommand('/robin some-other-text merge').isRobinCommand()).toBe(false);
+});
+
+test('doesn\'t identify correct command with dry-run flag at wrong position', () => {
+  expect(new RobinCommand('/robin --dry-run merge').isRobinCommand()).toBe(false);
+});
+
+test('doesn\'t identify command from empty message', () => {
+  expect(new RobinCommand('').isRobinCommand()).toBe(false);
+});
+
+test('finds dry-run flag', () => {
+  expect(new RobinCommand('/robin merge --dry-run').isDryRunMode()).toBe(true);
+});
+
+test('doesn\'t find dry-run flag when not passed', () => {
+  expect(new RobinCommand('/robin merge').isDryRunMode()).toBe(false);
+});


### PR DESCRIPTION
### What has been done
1. Added future merge commands support
2. Covered `RobinCommand` with tests

### How to test
1. Merge PR
2. Leave a comment on PR with allowed commands (e.g. `/robin merge --dry-run`)
3. Make sure action build passes and no warning printed to console
```
Robin helps only when he has been explicitly asked via \`/robin\` command.
            See https://github.com/vgaidarji/github-actions-pr-merger/tree/master#usage
```
