### PR TITLE
Hide GitHub payload in collapsible group in logs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,9 @@ const octokit = github.getOctokit(GITHUB_TOKEN);
 
 const main = async () => {
   try {
-    console.log(`GitHub payload ${JSON.stringify(githubContext.payload)}`);
+    core.startGroup('GitHub payload');
+    core.info(`${JSON.stringify(githubContext.payload)}`);
+    core.endGroup();
 
     const isComment = 'comment' in githubContext.payload;
     const isCommentCreatedAction = isComment && githubContext.payload.action == 'created';


### PR DESCRIPTION
### What has been done
1. Hid GitHub payload in collapsible group

### How to test
1. Merge PR
2. Leave a valid robin command comment to trigger action build
3. Confirm GitHub payload JSON response is collapsed in logs by default
