### PR TITLE
Do not catch errors from octokit requests

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,9 +45,6 @@ const fetchFullPullRequestObject = async () => {
     owner: issueCommentPayload.repository.owner.login,
     repo: issueCommentPayload.repository.name,
     pull_number: issueCommentPayload.issue.number,
-  }).catch((e) => {
-    console.log(e.message);
-    return failureOutput;
   });
   core.startGroup('PullRequest payload');
   core.info(`${JSON.stringify(currentPullRequest)}`);
@@ -94,9 +91,6 @@ const performMerge = async (pullRequest) => {
     commit_title: pullRequest.title,
     // Pass merge method from robin command
     merge_method: MergeMethod.MERGE,
-  }).catch((e) => {
-    console.log(e.message);
-    return failureOutput;
   });
   console.log(`Merge succeeded.`);
 };


### PR DESCRIPTION
### What has been done
1. Do not catch errors from octokit requests. `main` method's `try/catch` should catch the errors properly.

### How to test
1. Merge PR
2. Make the octokit request fail and confirm that error is caught in printed in logs
