### PR TITLE
Catch the error from PR merging promise

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -84,6 +84,9 @@ const performDryRunMerge = async (pullRequest) => {
 
 const performMerge = async (pullRequest) => {
   // https://docs.github.com/en/free-pro-team@latest/rest/reference/pulls#merge-a-pull-request
+  core.startGroup('See below the Pull Request being merged');
+  core.info(`${JSON.stringify(pullRequest)}`);
+  core.endGroup();
   await octokit.pulls.merge({
     owner: pullRequest.owner,
     repo: pullRequest.repo,
@@ -91,6 +94,8 @@ const performMerge = async (pullRequest) => {
     commit_title: pullRequest.title,
     // Pass merge method from robin command
     merge_method: MergeMethod.MERGE,
+  }).catch((e) => {
+    console.log('Failed to perform merge operation: ' + e.message);
   });
   console.log(`Merge succeeded.`);
 };


### PR DESCRIPTION
### What has been done
1. Added catch of the error from PR merging promise. This is in attempt to try to figure out why merging fails with error 
```
(node:1506) UnhandledPromiseRejectionWarning: HttpError: Not Found
    at /home/runner/work/github-actions-pr-merger/github-actions-pr-merger/node_modules/@octokit/request/dist-node/index.js:66:23
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async performMerge (/home/runner/work/github-actions-pr-merger/github-actions-pr-merger/src/index.js:87:3)
(node:1506) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
```

### How to test
1. Merge the PR 
2. Leave a `/robin merge` comment and test the action logs to see more descriptive error logs
